### PR TITLE
Fileset info handle array component type when Elt is SelectorExpr

### DIFF
--- a/fileset_info.go
+++ b/fileset_info.go
@@ -55,10 +55,10 @@ func NewFieldInfo(field *ast.Field) *FieldInfo {
 			case *ast.SelectorExpr:
 				result.ComponentType = y.X.(*ast.Ident).Name + "." + y.Sel.Name
 			}
+			result.IsPointerComponent = true
 		case *ast.SelectorExpr:
 			result.ComponentType = x.X.(*ast.Ident).Name + "." + x.Sel.Name
 		}
-		result.IsPointerComponent = true
 	}
 	_, result.IsPointer = field.Type.(*ast.StarExpr)
 	_, result.IsChannel = field.Type.(*ast.ChanType)

--- a/fileset_info.go
+++ b/fileset_info.go
@@ -55,7 +55,6 @@ func NewFieldInfo(field *ast.Field) *FieldInfo {
 			case *ast.SelectorExpr:
 				result.ComponentType = y.X.(*ast.Ident).Name + "." + y.Sel.Name
 			}
-			result.IsPointerComponent = true
 		case *ast.SelectorExpr:
 			result.ComponentType = x.X.(*ast.Ident).Name + "." + x.Sel.Name
 		}

--- a/fileset_info.go
+++ b/fileset_info.go
@@ -45,14 +45,21 @@ func NewFieldInfo(field *ast.Field) *FieldInfo {
 	_, result.IsMap = field.Type.(*ast.MapType)
 	var arrayType *ast.ArrayType
 	if arrayType, result.IsSlice = field.Type.(*ast.ArrayType); result.IsSlice {
-		if ident, ok := arrayType.Elt.(*ast.Ident); ok {
-			result.ComponentType = ident.Name
-		} else if startExpr, ok := arrayType.Elt.(*ast.StarExpr); ok {
-			if ident, ok := startExpr.X.(*ast.Ident); ok {
-				result.ComponentType = ident.Name
+		switch x := arrayType.Elt.(type) {
+		case *ast.Ident:
+			result.ComponentType = x.Name
+		case *ast.StarExpr:
+			switch y := x.X.(type) {
+			case *ast.Ident:
+				result.ComponentType = y.Name
+			case *ast.SelectorExpr:
+				result.ComponentType = y.X.(*ast.Ident).Name + "." + y.Sel.Name
 			}
 			result.IsPointerComponent = true
+		case *ast.SelectorExpr:
+			result.ComponentType = x.X.(*ast.Ident).Name + "." + x.Sel.Name
 		}
+		result.IsPointerComponent = true
 	}
 	_, result.IsPointer = field.Type.(*ast.StarExpr)
 	_, result.IsChannel = field.Type.(*ast.ChanType)

--- a/fileset_info_test.go
+++ b/fileset_info_test.go
@@ -85,7 +85,7 @@ func TestNewFileSetInfoInfo(t *testing.T) {
 	receiver := userInfo.Receiver("Test")
 	assert.NotNil(t, receiver)
 
-	appointments := userInfo.Receiver("Appointments")
+	appointments := userInfo.Field("Appointments")
 	assert.NotNil(t, appointments)
 	assert.Equal(t, "time.Time", appointments.ComponentType)
 

--- a/fileset_info_test.go
+++ b/fileset_info_test.go
@@ -85,4 +85,8 @@ func TestNewFileSetInfoInfo(t *testing.T) {
 	receiver := userInfo.Receiver("Test")
 	assert.NotNil(t, receiver)
 
+	appointments := userInfo.Receiver("Appointments")
+	assert.NotNil(t, appointments)
+	assert.Equal(t, "time.Time", appointments.ComponentType)
+
 }

--- a/fileset_info_test/user_test.go
+++ b/fileset_info_test/user_test.go
@@ -35,6 +35,7 @@ type User struct { //my comments
 	Ints2          Ints
 	M              map[string][]string
 	C              chan *bool
+	Appointments   []time.Time
 }
 
 //Test represents a test method

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -1,11 +1,12 @@
 package toolbox
 
 import (
-	"github.com/gin-gonic/gin/json"
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v2"
+	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestNormalizeKVPairs(t *testing.T) {


### PR DESCRIPTION
Hi,

I'd like to add the handling of `*ast.SelectorExpr` for a slice element in the `fileset_info.go`. 

Example: `[]time.Time` will get `time.Time` in the ComponentType value.

Thank you  

